### PR TITLE
[Dependency]Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,15 +22,15 @@ travis-ci = {repository = "wyyerd/pulsar-rs"}
 bytes = "0.5.0"
 crc = "1.0.0"
 futures = "0.3"
-nom = "5.0.0"
-prost = "0.6.0"
-prost-derive = "0.6.0"
-rand = "0.7"
-chrono = "0.4.6"
+nom = "6.0.0"
+prost = "0.7.0"
+prost-derive = "0.7.0"
+rand = "0.8"
+chrono = "0.4.19"
 futures-timer = "3.0"
-log = "0.4.6"
-url = "2.1"
-regex = "1.1.7"
+log = "0.4.13"
+url = "2.2"
+regex = "1.4.0"
 bit-vec = "0.6"
 futures-io = "0.3"
 native-tls = "0.2"
@@ -38,21 +38,21 @@ pem = "0.8"
 tokio = { version = "0.2", features = ["rt-threaded", "blocking", "full"], optional = true }
 tokio-util = { version = "0.3", features = ["codec"], optional = true }
 tokio-native-tls = { version = "0.1", optional = true }
-async-std = {version = "1.5", features = [ "attributes", "unstable" ], optional = true }
+async-std = {version = "1.9", features = [ "attributes", "unstable" ], optional = true }
 futures_codec = { version = "0.4", optional = true }
 async-native-tls = { version = "0.3", optional = true }
 lz4 = { version = "1.23", optional = true }
 flate2 = { version = "1.0", optional = true }
-zstd = { version = "0.5", optional = true }
+zstd = { version = "0.6", optional = true }
 snap = { version = "1.0", optional = true }
 
 [dev-dependencies]
-serde = { version = "1.0.101", features = ["derive"] }
-serde_json = "1.0.40"
-env_logger = "0.7"
+serde = { version = "1.0.120", features = ["derive"] }
+serde_json = "1.0.61"
+env_logger = "0.8"
 
 [build-dependencies]
-prost-build = "0.6.0"
+prost-build = "0.7.0"
 
 [features]
 default = [ "compression", "tokio-runtime", "async-std-runtime" ]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -475,7 +475,7 @@ impl Connection {
             .ok()
             .and_then(|v| {
                 let mut rng = thread_rng();
-                let index: usize = rng.gen_range(0, v.len());
+                let index: usize = rng.gen_range(0..v.len());
                 v.get(index).copied()
             })
         })

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -245,7 +245,7 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                         return Err(ConnectionError::Io(e));
                     }
 
-                    let jitter = rand::thread_rng().gen_range(0, 10);
+                    let jitter = rand::thread_rng().gen_range(0..10);
                     current_backoff = std::cmp::min(
                         self.back_off_options.min_backoff * 2u32.saturating_pow(current_retries),
                         self.back_off_options.max_backoff,

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1147,6 +1147,7 @@ impl<Exe: Executor> ConsumerBuilder<Exe> {
         let subscription = subscription.unwrap_or_else(|| {
             let s: String = (0..8)
                 .map(|_| rand::thread_rng().sample(Alphanumeric))
+                .map(char::from)
                 .collect();
             let subscription = format!("sub_{}", s);
             warn!(
@@ -1593,6 +1594,7 @@ mod tests {
         let message = TestData {
             topic: std::iter::repeat(())
                 .map(|()| rand::thread_rng().sample(Alphanumeric))
+                .map(char::from)
                 .take(8)
                 .collect(),
             msg: 1,


### PR DESCRIPTION
Closes #2 
* Update some dependencies to the latest version.

The following dependencies have not been updated:
* `bytes`: Cannot update bytes to 1.0.1 because futures_codec depend on bytes 0.5.6.
* `tokio`, `tokio-util` and `tokio-native-tls`: Cannot update tokio and relevant dependencies due to needing too many changes.
