### PR TITLE
cleanup the connection and trigger reconnection when ping failed

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -315,7 +315,10 @@ impl<Exe: Executor> ConnectionSender<Exe> {
 
                 match select(response, delay_f).await {
                     Either::Left((res, _)) => res
-                        .map_err(|oneshot::Canceled| ConnectionError::Disconnected)
+                        .map_err(|oneshot::Canceled| {
+                            self.error.set(ConnectionError::Disconnected);
+                            ConnectionError::Disconnected
+                        })
                         .map(move |_| trace!("received pong")),
                     Either::Right(_) => {
                         self.error.set(ConnectionError::Io(std::io::Error::new(

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -413,6 +413,11 @@ impl<Exe: Executor> ConnectionManager<Exe> {
                     trace!("will ping connection {} to {}", connection_id, broker_url);
                 }
                 if let Some(strong_conn) = weak_conn.upgrade() {
+                    if !strong_conn.is_valid() {
+                        trace!("connection {} is not valid anymore, skip heart beat task",
+                            connection_id);
+                        break;
+                    }
                     if let Err(e) = strong_conn.sender().send_ping().await {
                         error!(
                             "could not ping connection {} to the server at {}: {}",


### PR DESCRIPTION
### Motivation

When pulsar-rs check connection from consumer, it will send ping to the broker, but the failed ping request is not trigger `error` set, so the failed connection will not mark as invalid and will not remove from the connections pool. In this case, with `connection_retry_options`, the connection manager will always check the heart beat to keep the connection alive even if the connection is already closed. And it will cause the log flood about `could not ping connection $cid to the server at $broker: $err`.

### Modifications

- set connection error status when send ping failed
- ignore invalid connection when keep alive

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

