### PR TITLE
[cleanup] Remove travis file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: rust
-after_success: |
-  [ $TRAVIS_BRANCH = master ] &&
-  [ $TRAVIS_PULL_REQUEST = false ] &&
-  cargo doc &&
-  echo "<meta http-equiv=refresh content=0;url=`echo $TRAVIS_REPO_SLUG | cut -d '/' -f 2`/index.html>" > target/doc/index.html &&
-  sudo pip install ghp-import &&
-  ghp-import -n target/doc &&
-  git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages


### PR DESCRIPTION
### Motivation

Current we use GitHub action to run tests, So, I think it's time to remove the useless `travis.yml`.

### Modifications

- Remove the `travis.yml` file.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

- [x] `no-need-doc` 
 

